### PR TITLE
Created genre and music album classes

### DIFF
--- a/genre.rb
+++ b/genre.rb
@@ -1,0 +1,15 @@
+class Genre
+  attr_accessor :items, :name
+  attr_reader :id
+
+  def initialize(name)
+    @id = Random.rand(1..1000)
+    @name = name
+    @items = []
+  end
+
+  def add_item(music_album)
+    @items << music_album
+    music_album.genre = self
+  end
+end

--- a/music_album.rb
+++ b/music_album.rb
@@ -1,0 +1,14 @@
+require './item'
+
+class MusicAlbum < Item
+  attr_accessor :on_sportify
+
+  def initialize(publish_date, on_sportify)
+    super(publish_date)
+    @on_sportify = on_sportify
+  end
+
+  def can_be_archived?
+    super && @on_sportify
+  end
+end


### PR DESCRIPTION
At this juncture of development I implemented the following:

- Create `MusicAlbum class` in a separate `.rb file`.
- Create `Genre class` with an association to the `Item class` (in a separate `.rb file`).
- All `MusicAlbum class` properties visible in the [diagram](https://github.com/microverseinc/curriculum-ruby/blob/main/group-capstone/images/catalog_of_my_things.png).
- All `Genre class` properties visible in the [diagram](https://github.com/microverseinc/curriculum-ruby/blob/main/group-capstone/images/catalog_of_my_things.png).
- Implement methods:
    - `add_item` method in the `Genre class`
        - should take an instance of the `Item class` as an input
        - should add the input item to the collection of `items`
        - should add self as a property of the `item` object (by using the correct setter from the item object)
    - `can_be_archived?() in the `MusicAlbum class`
        - should override the method from the parent class
        - should return true if parent's method returns true AND if `on_spotify` equals `true`
        - otherwise, it should return `false`