### PR TITLE
Preserve and list games and authors

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,10 +1,13 @@
 require './modules/music_albums_module'
 require './modules/books_module'
+require './modules/games_module'
+
 class App
-  attr_accessor :books, :music_albums
+  attr_accessor :books, :music_albums, :games
 
   def initialize
     @books = BooksModule.new
     @music_albums = MusicAlbumsModule.new
+    @games = GamesModule.new
   end
 end

--- a/author.rb
+++ b/author.rb
@@ -14,4 +14,12 @@ class Author
     @items.push(item)
     item.author = self
   end
+
+  def to_json(*_args)
+    {
+      'id' => @id,
+      'first_name' => @first_name,
+      'last_name' => @last_name
+    }
+  end
 end

--- a/game.rb
+++ b/game.rb
@@ -14,4 +14,15 @@ class Game < Item
   def can_be_archived?
     super && (DateTime.now.strftime('%Y').to_i - last_played_at[6..10].to_i) > 2
   end
+
+  def to_json(*_args)
+    {
+      JSON.create_id => self.class.name,
+      'id' => @id,
+      'multiplayer' => @multiplayer,
+      'author' => @author,
+      'publication_date' => @publish_date,
+      'last_played_at' => @last_played_at
+    }
+  end
 end

--- a/modules/games_module.rb
+++ b/modules/games_module.rb
@@ -36,9 +36,7 @@ class GamesModule
     print 'Publication date: '
     publish_date = gets.chomp
 
-    multiplayer_status(multiplayer)
-
-    game = Game.new(multiplayer, last_played_at, publish_date)
+    game = Game.new(multiplayer_status(multiplayer), last_played_at, publish_date)
     game.add_author("#{author_first_name} #{author_last_name}")
     # store game
     store_game(game)

--- a/modules/games_module.rb
+++ b/modules/games_module.rb
@@ -1,4 +1,5 @@
 require './game'
+require './author'
 require 'json'
 
 class GamesModule
@@ -10,11 +11,21 @@ class GamesModule
     games_file = File.open(@games_file_location)
     @games = games_file.size.zero? ? [] : JSON.parse(games_file.read)
     games_file.close
+
+    # authors file
+    @authors_file_location = 'storage/authors.json'
+    authors_file = File.open(@authors_file_location)
+    @authors = authors_file.size.zero? ? [] : JSON.parse(authors_file.read)
+    authors_file.close
   end
 
   # add game
   def add_game
-    print 'Author: '
+    print "Author's first name: "
+    author_first_name = gets.chomp
+
+    print "Author's last name: "
+    author_last_name = gets.chomp
 
     print 'Multiplayer? (yes or no ): '
     multiplayer = gets.chomp
@@ -25,16 +36,15 @@ class GamesModule
     print 'Publication date: '
     publish_date = gets.chomp
 
-    case multiplayer
-    when 'Y', 'y', 'yes', 'Yes'
-      multiplayer = true
-    when 'n', 'N', 'no', 'No'
-      multiplayer = false
-    end
+    multiplayer_status(multiplayer)
 
     game = Game.new(multiplayer, last_played_at, publish_date)
+    game.add_author("#{author_first_name} #{author_last_name}")
     # store game
     store_game(game)
+
+    # store author
+    store_author(Author.new(author_first_name, author_first_name))
 
     puts 'Game created successfully'
   end
@@ -46,5 +56,23 @@ class GamesModule
     file = File.open(@games_file_location, 'w')
     file.write(JSON[@games])
     file.close
+  end
+
+  def store_author(created_author)
+    created_author = created_author.to_json
+    @authors << created_author
+
+    file = File.open(@authors_file_location, 'w')
+    file.write(JSON[@authors])
+    file.close
+  end
+
+  def multiplayer_status(multiplayer)
+    case multiplayer
+    when 'Y', 'y', 'yes', 'Yes'
+      true
+    when 'n', 'N', 'no', 'No'
+      false
+    end
   end
 end

--- a/modules/games_module.rb
+++ b/modules/games_module.rb
@@ -73,4 +73,15 @@ class GamesModule
       false
     end
   end
+
+  # list games
+  def list_games
+    if @games.empty?
+      puts 'Sorry, the games list is currently empty'
+    else
+      @games.each_with_index do |game, i|
+        puts "#{i + 1}. Multiplayer: \"#{game['multiplayer']}\", Author: #{game['author']}"
+      end
+    end
+  end
 end

--- a/modules/games_module.rb
+++ b/modules/games_module.rb
@@ -84,4 +84,15 @@ class GamesModule
       end
     end
   end
+
+  # list authors
+  def list_authors
+    if @authors.empty?
+      puts 'Sorry, the authors list is currently empty'
+    else
+      @authors.each_with_index do |author, i|
+        puts "#{i + 1}. Name: #{author['first_name']} #{author['last_name']}"
+      end
+    end
+  end
 end

--- a/modules/games_module.rb
+++ b/modules/games_module.rb
@@ -1,0 +1,50 @@
+require './game'
+require 'json'
+
+class GamesModule
+  attr_reader :games
+
+  def initialize
+    # games file
+    @games_file_location = 'storage/games.json'
+    games_file = File.open(@games_file_location)
+    @games = games_file.size.zero? ? [] : JSON.parse(games_file.read)
+    games_file.close
+  end
+
+  # add game
+  def add_game
+    print 'Author: '
+
+    print 'Multiplayer? (yes or no ): '
+    multiplayer = gets.chomp
+
+    print 'Enter last played date: '
+    last_played_at = gets.chomp
+
+    print 'Publication date: '
+    publish_date = gets.chomp
+
+    case multiplayer
+    when 'Y', 'y', 'yes', 'Yes'
+      multiplayer = true
+    when 'n', 'N', 'no', 'No'
+      multiplayer = false
+    end
+
+    game = Game.new(multiplayer, last_played_at, publish_date)
+    # store game
+    store_game(game)
+
+    puts 'Game created successfully'
+  end
+
+  def store_game(game)
+    game = game.to_json
+    @games << game
+
+    file = File.open(@games_file_location, 'w')
+    file.write(JSON[@games])
+    file.close
+  end
+end

--- a/modules/games_module.rb
+++ b/modules/games_module.rb
@@ -42,7 +42,7 @@ class GamesModule
     store_game(game)
 
     # store author
-    store_author(Author.new(author_first_name, author_first_name))
+    store_author(Author.new(author_first_name, author_last_name))
 
     puts 'Game created successfully'
   end

--- a/schema.sql
+++ b/schema.sql
@@ -21,3 +21,18 @@ CREATE TABLE genres (
   id INT GENERATED ALWAYS AS IDENTITY,
   name VARCHAR(100)
 );
+
+CREATE TABLE games (
+  id INT GENERATED ALWAYS AS IDENTITY,
+  FOREIGN KEY(author_id) REFERENCES author(id)
+  publish_date DATE,
+  last_played_at DATE,
+  archived BOOLEAN,
+  multiplayer BOOLEAN,
+);
+
+CREATE TABLE authors (
+  id INT GENERATED ALWAYS AS IDENTITY,
+  first_name VARCHAR(100)
+  last_name VARCHAR(100)
+);

--- a/start.rb
+++ b/start.rb
@@ -29,7 +29,7 @@ class Start
     when 5
       @app.books.list_all_labels
     else
-      @app.authors.list_authors
+      @app.games.list_authors
     end
   end
 

--- a/storage/authors.json
+++ b/storage/authors.json
@@ -1,0 +1,4 @@
+[
+  { "id": 523, "first_name": "Mark", "last_name": "Mark" },
+  { "id": 559, "first_name": "aaaa", "last_name": "aaaa" }
+]

--- a/storage/authors.json
+++ b/storage/authors.json
@@ -1,4 +1,5 @@
 [
   { "id": 523, "first_name": "Mark", "last_name": "Mark" },
-  { "id": 559, "first_name": "aaaa", "last_name": "aaaa" }
+  { "id": 559, "first_name": "aaaa", "last_name": "aaaa" },
+  { "id": 247, "first_name": "Alphy", "last_name": "Alphy" }
 ]

--- a/storage/games.json
+++ b/storage/games.json
@@ -1,18 +1,1 @@
-[
-  {
-    "json_class": "Game",
-    "id": 751,
-    "multiplayer": false,
-    "author": "Mark Cerny",
-    "publication_date": "2007/09/12",
-    "last_played_at": "2022/09/08"
-  },
-  {
-    "json_class": "Game",
-    "id": 354,
-    "multiplayer": true,
-    "author": "aaaa bbbb",
-    "publication_date": "2007/09/12",
-    "last_played_at": "2022/09/08"
-  }
-]
+[{"json_class":"Game","id":751,"multiplayer":false,"author":"Mark Cerny","publication_date":"2007/09/12","last_played_at":"2022/09/08"},{"json_class":"Game","id":354,"multiplayer":true,"author":"aaaa bbbb","publication_date":"2007/09/12","last_played_at":"2022/09/08"},{"json_class":"Game","id":690,"multiplayer":false,"author":"Alphy Gacheru","publication_date":"1903","last_played_at":"2020"}]

--- a/storage/games.json
+++ b/storage/games.json
@@ -1,0 +1,18 @@
+[
+  {
+    "json_class": "Game",
+    "id": 751,
+    "multiplayer": false,
+    "author": "Mark Cerny",
+    "publication_date": "2007/09/12",
+    "last_played_at": "2022/09/08"
+  },
+  {
+    "json_class": "Game",
+    "id": 354,
+    "multiplayer": true,
+    "author": "aaaa bbbb",
+    "publication_date": "2007/09/12",
+    "last_played_at": "2022/09/08"
+  }
+]


### PR DESCRIPTION
At this juncture of development I implemented the following:
    - Add a game
    - List of games
    - List all authors 
  
 -  preserve games and authors by saving collections in .json files.
 - Create a schema.sql file with tables that will be analogical to the structure of the classes that I created:
 - games table (with all properties and associations from the parent Item class as table columns)
 - authors table